### PR TITLE
fix(migrations): only return `file` and `path` properties

### DIFF
--- a/packages/migrator/readme.md
+++ b/packages/migrator/readme.md
@@ -3,11 +3,13 @@
 [![Build Status](https://travis-ci.org/mmkal/slonik-tools.svg?branch=master)](https://travis-ci.org/mmkal/slonik-tools)
 [![Coverage Status](https://coveralls.io/repos/github/mmkal/slonik-tools/badge.svg?branch=master)](https://coveralls.io/github/mmkal/slonik-tools?branch=master)
 
-A cli migration helper tool using [slonik](https://npmjs.com/package/slonik).
+A cli migration tool for postgres sql scripts, using [slonik](https://npmjs.com/package/slonik).
 
 ## Motivation
 
-There are already plenty of migration tools out there - but if you have an existing project that uses slonik, this will be by far the simplest to configure. Even if you don't, the setup required is minimal.
+There are already plenty of migration tools out there - but if you have an existing project that uses slonik, this will be the simplest to configure. Even if you don't, the setup required is minimal.
+
+The migration scripts it runs are just `.sql` files. No learning the quirks of an ORM, any niche library's DSL.
 
 This isn't a cli tool - it's a cli tool _helper_. Most node migration libraries are command-line utilities, which require a separate `database.json` or `config.json` file where you have to hard-code in your connection credentials. This library uses a different approach - it exposes a javascript function which you pass a slonik instance into. The javascript file you make that call in then becomes a runnable migration script.
 
@@ -61,9 +63,11 @@ To run migrations programmatically, you can import the `migrator` object, say in
 import {migrator, slonik} from './migrate'
 import {sql} from 'slonik'
 
-export const foo = async () => {
-  await migrator.up()
-  await slonik.query(sql`insert into users(name) values('foo')`)
+export const seed = async () => {
+  const migrations = await migrator.up()
+  if (migrations.some(m => m.file.endsWith('.users.sql'))) {
+    await slonik.query(sql`insert into users(name) values('foo')`)
+  }
 }
 ```
 

--- a/packages/migrator/src/index.ts
+++ b/packages/migrator/src/index.ts
@@ -1,6 +1,7 @@
 import {createHash} from 'crypto'
 import {readFileSync, writeFileSync, mkdirSync, readdirSync} from 'fs'
 import {once, memoize} from 'lodash'
+import {map, pick} from 'lodash/fp'
 import {basename, dirname, join} from 'path'
 import * as Umzug from 'umzug'
 import {sql, DatabasePoolType} from 'slonik'
@@ -102,9 +103,9 @@ export const setupSlonikMigrator = ({
     },
   })
 
-  const migrator = {
-    up: (name?: string) => umzug.up(name),
-    down: (name?: string) => umzug.down(name),
+  const migrator: SlonikMigrator = {
+    up: (name?: string) => umzug.up(name).then(map(pick(['file', 'path']))),
+    down: (name?: string) => umzug.down(name).then(map(pick(['file', 'path']))),
     create: (name: string) => {
       const timestamp = new Date().toISOString().replace(/\W/g, '-').replace(/-\d\d-\d\d\dZ/, '')
       const sqlFileName = `${timestamp}.${name}.sql`

--- a/packages/migrator/test/cli.test.ts
+++ b/packages/migrator/test/cli.test.ts
@@ -68,9 +68,18 @@ it('migrates', async () => {
   writeFileSync(file(/two\.sql/), 'create table migration_two(x text)')
   writeFileSync(file(/down.*two\.sql/), 'drop table migration_two')
 
-  await migrator.up()
+  const up1 = await migrator.up()
 
+  expect(up1).toMatchObject([
+    {file: expect.stringContaining('one.sql'), path: expect.stringContaining('one.sql')},
+    {file: expect.stringContaining('two.sql'), path: expect.stringContaining('two.sql')},
+  ])
+  
   expect(await migrationTables()).toEqual(['migration', 'migration_one', 'migration_two'])
+  
+  const up2 = await migrator.up()
+
+  expect(up2).toEqual([])
 
   await migrator.down()
 


### PR DESCRIPTION
This avoids adding umzug-specific data in the api surface.