### PR TITLE
feat(enums): auto generate enum types

### DIFF
--- a/packages/demo/migrations/2020-04-06T01-19.message-priority.sql
+++ b/packages/demo/migrations/2020-04-06T01-19.message-priority.sql
@@ -1,0 +1,4 @@
+create type message_priority as enum('low', 'medium', 'high');
+
+alter table messages
+add column priority message_priority;

--- a/packages/demo/migrations/down/2020-04-06T01-19.message-priority.sql
+++ b/packages/demo/migrations/down/2020-04-06T01-19.message-priority.sql
@@ -1,0 +1,4 @@
+alter table messages
+drop column priority;
+
+drop type message_priority;

--- a/packages/demo/src/generated/db/Message.ts
+++ b/packages/demo/src/generated/db/Message.ts
@@ -10,6 +10,8 @@ export type Message_AllTypes = [
     content: string
     /** pg_type.typname: timestamptz */
     created_at: Date
+    /** pg_type.typname: message_priority */
+    priority: 'low' | 'medium' | 'high'
   }
 ]
 export interface Message_QueryTypeMap {
@@ -26,4 +28,4 @@ export type Message = {
 }
 export const Message = {} as Message
 
-export const Message_meta_v0 = [{"properties":[{"name":"id","value":"number","description":"pg_type.typname: int4"},{"name":"content","value":"string","description":"pg_type.typname: varchar"},{"name":"created_at","value":"Date","description":"pg_type.typname: timestamptz"}],"description":"select * from messages\n        where id < $1\n        order by created_at desc\n        limit 10"}]
+export const Message_meta_v0 = [{"properties":[{"name":"id","value":"number","description":"pg_type.typname: int4"},{"name":"content","value":"string","description":"pg_type.typname: varchar"},{"name":"created_at","value":"Date","description":"pg_type.typname: timestamptz"},{"name":"priority","value":"'low' | 'medium' | 'high'","description":"pg_type.typname: message_priority"}],"description":"select * from messages\n        where id < $1\n        order by created_at desc\n        limit 10"}]

--- a/packages/demo/src/generated/db/_pg_types.ts
+++ b/packages/demo/src/generated/db/_pg_types.ts
@@ -48,6 +48,7 @@ export const _pg_types = {
   lseg: 'lseg',
   macaddr: 'macaddr',
   macaddr8: 'macaddr8',
+  message_priority: 'message_priority',
   money: 'money',
   name: 'name',
   numeric: 'numeric',

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -24,8 +24,8 @@ const groupBy = <T>(list: T[], getKey: (value: T) => string | number) => {
   const record: Record<string, T[] | undefined> = {}
   list.forEach(value => {
     const key = getKey(value)
-    const group = (record[key] = record[key] || [])
-    group.push(value)
+    record[key] = record[key] || []
+    record[key]!.push(value)
   })
   return record
 }

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -24,8 +24,8 @@ const groupBy = <T>(list: T[], getKey: (value: T) => string | number) => {
   const record: Record<string, T[] | undefined> = {}
   list.forEach(value => {
     const key = getKey(value)
-    record[key] = record[key] || []
-    record[key]?.push(value)
+    const group = (record[key] = record[key] || [])
+    group.push(value)
   })
   return record
 }

--- a/packages/typegen/test/generated/main/Bar.ts
+++ b/packages/typegen/test/generated/main/Bar.ts
@@ -5,7 +5,7 @@
 export type Bar_AllTypes = [
   {
     /** pg_type.typname: direction */
-    dir: 'up' | 'down'
+    dir: 'up' | 'down' | 'left' | 'right'
   }
 ]
 export interface Bar_QueryTypeMap {
@@ -19,4 +19,4 @@ export type Bar = {
 }
 export const Bar = {} as Bar
 
-export const Bar_meta_v0 = [{"properties":[{"name":"dir","value":"'up' | 'down'","description":"pg_type.typname: direction"}],"description":"select * from bar"}]
+export const Bar_meta_v0 = [{"properties":[{"name":"dir","value":"'up' | 'down' | 'left' | 'right'","description":"pg_type.typname: direction"}],"description":"select * from bar"}]

--- a/packages/typegen/test/generated/main/_pg_types.ts
+++ b/packages/typegen/test/generated/main/_pg_types.ts
@@ -48,6 +48,7 @@ export const _pg_types = {
   lseg: 'lseg',
   macaddr: 'macaddr',
   macaddr8: 'macaddr8',
+  message_priority: 'message_priority',
   money: 'money',
   name: 'name',
   numeric: 'numeric',

--- a/packages/typegen/test/generated/with-custom-date/_pg_types.ts
+++ b/packages/typegen/test/generated/with-custom-date/_pg_types.ts
@@ -48,6 +48,7 @@ export const _pg_types = {
   lseg: 'lseg',
   macaddr: 'macaddr',
   macaddr8: 'macaddr8',
+  message_priority: 'message_priority',
   money: 'money',
   name: 'name',
   numeric: 'numeric',

--- a/packages/typegen/test/generated/with-date/_pg_types.ts
+++ b/packages/typegen/test/generated/with-date/_pg_types.ts
@@ -48,6 +48,7 @@ export const _pg_types = {
   lseg: 'lseg',
   macaddr: 'macaddr',
   macaddr8: 'macaddr8',
+  message_priority: 'message_priority',
   money: 'money',
   name: 'name',
   numeric: 'numeric',


### PR DESCRIPTION
fixes https://github.com/mmkal/slonik-tools/issues/163

Hand-written `typeMappers` are no longer required for postgres enums, e.g.:

```sql
create type abc as enum('foo',  'bar')
```

The above will automatically translate to a typescript [string literal type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types) of `'foo' | 'bar'`.