### PR TITLE
feat: allow migrations table to be created  in different schema

### DIFF
--- a/packages/migrator/src/index.ts
+++ b/packages/migrator/src/index.ts
@@ -77,7 +77,7 @@ export const defaultResolvers = {
 export const setupSlonikMigrator = ({
   slonik,
   migrationsPath,
-  migrationTableName = ['public', 'migration'],
+  migrationTableName = 'migration',
   log = memoize(console.log, JSON.stringify),
   mainModule,
 }: SlonikMigratorOptions) => {


### PR DESCRIPTION
The following changes will allow you to target a different schema as the default one (`public`).

We currently use `@slonik/migrator` in a bunch of projects but have had to patch it with this change to allow us to target a different schema to create the migrations table in. Our data is split up in different schemas and different entities have granular control over their own schema. We also wanted the migrator to only put the migrations specific to that schema in the same schema. This ment making sure we can target the schema when we create the migrations table.

Because `migrationsTableName` is being run through `sql.identifier` it was impossible to pass something like `otherschema.migration`.

This change opens up `migrationsTableName` to be an array so it can be passed to `sql.identifier` properly and different schemas can be targeted.