### PR TITLE
chore: support slonik 27

### DIFF
--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/mmkal/slonik-tools/tree/master/packages/migrator#readme",
   "dependencies": {
+    "slonik": "^27.1.0",
     "umzug": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/migrator/src/index.ts
+++ b/packages/migrator/src/index.ts
@@ -2,20 +2,20 @@ import {createHash} from 'crypto'
 import {readFileSync} from 'fs'
 import {basename, dirname, join} from 'path'
 import * as umzug from 'umzug'
-import {sql, DatabaseTransactionConnectionType, DatabasePoolConnectionType, DatabasePoolType} from 'slonik'
+import {sql, DatabaseTransactionConnection, DatabasePoolConnection, DatabasePool} from 'slonik'
 import * as path from 'path'
 import * as templates from './templates'
 
 interface SlonikMigratorContext {
-  parent: DatabasePoolType
-  connection: DatabaseTransactionConnectionType
+  parent: DatabasePool
+  connection: DatabaseTransactionConnection
   sql: typeof sql
 }
 
 export class SlonikMigrator extends umzug.Umzug<SlonikMigratorContext> {
   constructor(
     private slonikMigratorOptions: {
-      slonik: DatabasePoolType
+      slonik: DatabasePool
       migrationsPath: string
       migrationTableName: string | string[]
       logger: umzug.UmzugOptions['logger']
@@ -219,17 +219,17 @@ export class SlonikMigrator extends umzug.Umzug<SlonikMigratorContext> {
 export type Migration = (
   params: umzug.MigrationParams<SlonikMigratorContext> & {
     /** @deprecated use `context.connection` */
-    slonik: DatabaseTransactionConnectionType
+    slonik: DatabaseTransactionConnection
     /** @deprecated use `context.sql` */
     sql: typeof sql
   },
 ) => Promise<unknown>
 
 /**
- * Should either be a `DatabasePoolType` or `DatabasePoolConnectionType`. If it's a `DatabasePoolType` with an `.end()`
+ * Should either be a `DatabasePool` or `DatabasePoolConnection`. If it's a `DatabasePool` with an `.end()`
  * method, the `.end()` method will be called after running the migrator as a CLI.
  */
-export interface SlonikConnectionType extends DatabasePoolConnectionType {
+export interface SlonikConnectionType extends DatabasePoolConnection {
   end?: () => Promise<void>
 }
 
@@ -238,7 +238,7 @@ export interface SlonikMigratorOptions {
    * Slonik instance for running migrations. You can import this from the same place as your main application,
    * or import another slonik instance with different permissions, security settings etc.
    */
-  slonik: DatabasePoolType
+  slonik: DatabasePool
   /**
    * Path to folder that will contain migration files.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6239,7 +6239,12 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@0.0.8, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -8005,6 +8010,30 @@ slonik@26.2.2:
   version "26.2.2"
   resolved "https://registry.yarnpkg.com/slonik/-/slonik-26.2.2.tgz#208760442881bd3c862afafec986a9e017029b54"
   integrity sha512-7IS4+b8rMkOE7xFbdLIs2XuEHKWmeWMjpbsnUnZjCd2nPANmxLHD6AWyeXL8nZnVlJPVtNWxDmeSxGG2bsMWcg==
+  dependencies:
+    concat-stream "^2.0.0"
+    es6-error "^4.1.1"
+    fast-safe-stringify "^2.1.1"
+    get-stack-trace "^2.1.1"
+    hyperid "^2.3.1"
+    is-plain-object "^5.0.0"
+    iso8601-duration "^1.3.0"
+    p-defer "^3.0.0"
+    pg "^8.7.1"
+    pg-copy-streams "^6.0.2"
+    pg-copy-streams-binary "^2.2.0"
+    pg-cursor "^2.7.1"
+    pg-protocol "^1.5.0"
+    postgres-array "^3.0.1"
+    postgres-interval "^4.0.0"
+    roarr "^7.8.0"
+    serialize-error "^8.0.0"
+    through2 "^4.0.2"
+
+slonik@^27.1.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/slonik/-/slonik-27.1.0.tgz#6cd878742329ff84873fc4dedafc6a39b4bdf54d"
+  integrity sha512-dZYChx5HIuhoB84oiQNbNSnLEF0/BAhn+4xhA7jvngxqfzdRrm2TvxffHAKDP0MZBd6e1rmzCV+Ap8LF81nmzQ==
   dependencies:
     concat-stream "^2.0.0"
     es6-error "^4.1.1"


### PR DESCRIPTION
Added what seems to be like the minimal code to support Slonik 27.

I tested locally using `npm link`, but did encounter error building `slonik-tools` at various levels.