### PR TITLE
fix(nullability): non-nullability of aliased count aggregation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
     },
   },
   collectCoverageFrom: ['**/*.ts', '!**/*.d.ts', '!**/generated/**', '!**/fixtures/**'],
+  watchPathIgnorePatterns: ['fixtures', 'generated'],
 }

--- a/packages/typegen/src/query/column-info.ts
+++ b/packages/typegen/src/query/column-info.ts
@@ -241,7 +241,7 @@ export const isFieldNotNull = (sql: string, field: QueryField) => {
       if (c.expr.type !== 'call' || c.expr.function.name !== 'count') {
         return false
       }
-      const name = c.alias || 'count'
+      const name = c.alias?.name || 'count'
       return field.name === name
     })
 

--- a/packages/typegen/test/options.test.ts
+++ b/packages/typegen/test/options.test.ts
@@ -44,6 +44,8 @@ test('write types', async () => {
           sql\`select * from options_test.test_table\`,
           sql\`select id, t from test_table\`,
           sql\`select count(*) from test_table\`,
+          sql\`select count(*) from test_table group by id\`,
+          sql\`select count(*) as cnt from test_table\`,
           sql\`select id as idalias, t as talias from test_table\`,
           sql\`select id from test_table where id = ${'${1}'} and n = ${'${2}'}\`,
           sql\`insert into test_table(id, j_nn, jb_nn) values (1, '{}', '{}')\`,
@@ -87,6 +89,8 @@ test('write types', async () => {
         sql<queries.TestTable>\`select * from options_test.test_table\`,
         sql<queries.TestTable_id_t>\`select id, t from test_table\`,
         sql<queries.TestTable_count>\`select count(*) from test_table\`,
+        sql<queries.TestTable_count>\`select count(*) from test_table group by id\`,
+        sql<queries.TestTable_cnt>\`select count(*) as cnt from test_table\`,
         sql<queries.TestTable_idalias_talias>\`select id as idalias, t as talias from test_table\`,
         sql<queries.TestTable_id>\`select id from test_table where id = \${1} and n = \${2}\`,
         sql<queries._void>\`insert into test_table(id, j_nn, jb_nn) values (1, '{}', '{}')\`,
@@ -184,10 +188,20 @@ test('write types', async () => {
           t: string | null
         }
       
-        /** - query: \`select count(*) from test_table\` */
+        /**
+         * queries:
+         * - \`select count(*) from test_table\`
+         * - \`select count(*) from test_table group by id\`
+         */
         export interface TestTable_count {
           /** not null: \`true\`, regtype: \`bigint\` */
           count: number
+        }
+      
+        /** - query: \`select count(*) as cnt from test_table\` */
+        export interface TestTable_cnt {
+          /** not null: \`true\`, regtype: \`bigint\` */
+          cnt: number
         }
       
         /** - query: \`select id as idalias, t as talias from test_table\` */


### PR DESCRIPTION
This fixes a bug, where this query

```sql
select count(*) as cnt
```
would return mistakenly return this type:
```typescript
cnt: number | null;
```

Count is guaranteed to be not null - from the [PSQL Docs](https://www.postgresql.org/docs/9.2/functions-aggregate.html):
> It should be noted that except for count, these functions return a null value when no rows are selected.

Tests were added to confirm.

Note: The change in jest.config.js is due to the fact that `jest --watch` was unusable, because every fixture render kept restarting the test(s).