### PR TITLE
fix(typegen): don't let semicolons cause queries to be executed

### DIFF
--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -46,6 +46,8 @@ export const generate = async (params: Partial<Options>) => {
   const {psql: _psql, getEnumTypes, getRegtypeToPGType} = psqlClient(`${psqlCommand} "${connectionURI}"`, pool)
 
   const _gdesc = async (sql: string) => {
+    // fix commented out initially to make sure test fails in CI
+    // assert.ok(!sql.includes(';'), `Can't use \\gdesc on query containing a semicolon`)
     try {
       return await psql(`${sql} \\gdesc`)
     } catch (e) {
@@ -210,6 +212,9 @@ export const generate = async (params: Partial<Options>) => {
         let message = `${getLogQueryReference(query)} [!] Extracting types from query failed: ${e}.`
         if (query.sql.includes('--')) {
           message += ' Try moving comments to dedicated lines.'
+        }
+        if (query.sql.includes(';')) {
+          message += ` Try removing trailing semicolons, separating multi-statement queries into separate queries, using a template variable for semicolons inside strings, or ignoring this query.`
         }
         logger.warn(message)
         return null

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -47,6 +47,7 @@ export const generate = async (params: Partial<Options>) => {
 
   const _gdesc = async (sql: string) => {
     // fix commented out initially to make sure test fails in CI
+    // sql = sql.trim().replace(/;$/, '')
     // assert.ok(!sql.includes(';'), `Can't use \\gdesc on query containing a semicolon`)
     try {
       return await psql(`${sql} \\gdesc`)

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -46,9 +46,8 @@ export const generate = async (params: Partial<Options>) => {
   const {psql: _psql, getEnumTypes, getRegtypeToPGType} = psqlClient(`${psqlCommand} "${connectionURI}"`, pool)
 
   const _gdesc = async (sql: string) => {
-    // fix commented out initially to make sure test fails in CI
-    // sql = sql.trim().replace(/;$/, '')
-    // assert.ok(!sql.includes(';'), `Can't use \\gdesc on query containing a semicolon`)
+    sql = sql.trim().replace(/;$/, '')
+    assert.ok(!sql.includes(';'), `Can't use \\gdesc on query containing a semicolon`)
     try {
       return await psql(`${sql} \\gdesc`)
     } catch (e) {

--- a/packages/typegen/test/limitations.test.ts
+++ b/packages/typegen/test/limitations.test.ts
@@ -349,7 +349,8 @@ test('queries with semicolons are rejected', async () => {
       'index.ts': `
         import {sql} from 'slonik'
 
-        export default sql\`create table semicolon_query_table(x int);\`
+        export const trailingSemicolon = sql\`create table semicolon_query_table1(x int);\`
+        export const trailingSemicolonWithComment = sql\`create table semicolon_query_table2(x int); -- I love semicolons\`
       `,
     },
   })
@@ -361,17 +362,18 @@ test('queries with semicolons are rejected', async () => {
   // running typegen should not have executed the `create table` statement!!!!
   expect(
     await helper.pool.any(
-      helper.sql`select table_schema, table_name from information_schema.tables where table_name = 'semicolon_query_table'`,
+      helper.sql`select table_schema, table_name from information_schema.tables where table_name like 'semicolon_query_table%'`,
     ),
   ).toEqual([])
 
   expect(logger.warn).toMatchInlineSnapshot(`
     - - >-
-        ./packages/typegen/test/fixtures/limitations.test.ts/queries-with-semicolons-are-rejected/index.ts:3
+        ./packages/typegen/test/fixtures/limitations.test.ts/queries-with-semicolons-are-rejected/index.ts:4
         [!] Extracting types from query failed: AssertionError [ERR_ASSERTION]:
-        Can't use \\gdesc on query containing a semicolon. Try removing trailing
-        semicolons, separating multi-statement queries into separate queries, using
-        a template variable for semicolons inside strings, or ignoring this query.
+        Can't use \\gdesc on query containing a semicolon. Try moving comments to
+        dedicated lines. Try removing trailing semicolons, separating
+        multi-statement queries into separate queries, using a template variable for
+        semicolons inside strings, or ignoring this query.
 
-    `)
+`)
 })


### PR DESCRIPTION
It was possible to make `psql` accidentally execute statements if they ended with a semicolon. The problem:

```
echo 'create table foo1(id int); \gdesc' | psql -f -
```

Actually _executes_ `create table foo(id int)` and ignores the `\gdesc` part as an invalid command. This works around by banning semicolons altogether unless they're the last character, in which case they'll be trimmed. Parsing the query would probably be better but it's harder to be sure it's safe that way.