### PR TITLE
fix(tsPrettify): Error when processing .sql files

### DIFF
--- a/packages/typegen/src/write/prettify.ts
+++ b/packages/typegen/src/write/prettify.ts
@@ -21,7 +21,7 @@ export function prettifyOne({filepath, content}: {filepath: string; content: str
  */
 export const tsPrettify = (uglyContent: string) => {
   const ts: typeof import('typescript') = require('typescript')
-  const sourceFile = ts.createSourceFile(__filename, uglyContent, ts.ScriptTarget.ES2015, true)
+  const sourceFile = ts.createSourceFile('', uglyContent, ts.ScriptTarget.ES2015, true)
   const prettyContent = ts.createPrinter().printNode(ts.EmitHint.SourceFile, sourceFile, sourceFile)
   return prettyContent
     .replace(/\nexport /g, '\n\nexport ') // typescript printer squashes everything a bit too much

--- a/packages/typegen/src/write/sql.ts
+++ b/packages/typegen/src/write/sql.ts
@@ -115,7 +115,7 @@ export function getSQLHelperContent(query: TaggedQuery, destPath: string) {
       ${defaults.paramsProp}
     }
 
-    export const _queryCache: Map<string, string> = new Map()
+    export const _queryCache = new Map<string, string>()
 
     export const defaultReadFileSync = (filepath: string) => {
       const cached = _queryCache.get(filepath)

--- a/packages/typegen/src/write/sql.ts
+++ b/packages/typegen/src/write/sql.ts
@@ -115,7 +115,7 @@ export function getSQLHelperContent(query: TaggedQuery, destPath: string) {
       ${defaults.paramsProp}
     }
 
-    export const _queryCache = new Map<string, string>()
+    export const _queryCache: Map<string, string> = new Map()
 
     export const defaultReadFileSync = (filepath: string) => {
       const cached = _queryCache.get(filepath)


### PR DESCRIPTION
This fixes https://github.com/mmkal/slonik-tools/issues/379

It seems typescript >4.2 doesn't like `const x = new Map<string, string>()` when using `createSourceFile`, for details see issue.

This is an easy workaround.